### PR TITLE
Refactor reviewPR function to remove unnecessary parameter

### DIFF
--- a/diffparser.ts
+++ b/diffparser.ts
@@ -65,12 +65,10 @@ export async function createInlineCommentsFromDiff(diff: string, context: any, a
         const filePath = file.to || file.from;
 
         for (const chunk of file.chunks) {
-            const diffHunk = chunk.content; // The full chunk content is the diff hunk
-
             for (const change of chunk.changes) {
                 if (change.type !== 'add') continue; // Focus on additions for comments
 
-                const line = change.ln; // Use the added line number
+                const line = change.ln; // Line number in the new file
                 const content = change.content.slice(1).trim();
                 const body = `Suggested change:\n\`\`\`suggestion\n${content}\n\`\`\``;
 
@@ -81,10 +79,13 @@ export async function createInlineCommentsFromDiff(diff: string, context: any, a
                         pull_number: pull_request.number,
                         commit_id: pull_request.head.sha,
                         path: filePath,
-                        side: 'RIGHT', // Comments are on the 'RIGHT' side for additions
-                        line, // Line number for unified diff
-                        diff_hunk: diffHunk, // Full context of the hunk
+                        side: 'RIGHT', // Comments on the RIGHT side for additions
+                        line,
                         body,
+                        // Enable comfort-fade preview to use line and side parameters
+                        mediaType: {
+                            previews: ['comfort-fade']
+                        }
                     });
                     app.log.info(`Created comment on ${filePath} line ${line}`);
                 } catch (error: any) {

--- a/diffparser.ts
+++ b/diffparser.ts
@@ -66,6 +66,9 @@ export async function createInlineCommentsFromDiff(diff: string, context: any, a
         const filePath = file.to || file.from; // Use the new file path if available, otherwise the old one
 
         for (const chunk of file.chunks) {
+            // Extract the diff hunk for this chunk
+            const diffHunk = chunk.content;
+
             for (const change of chunk.changes) {
                 if (change.type !== 'add' && change.type !== 'del') continue;
 
@@ -89,6 +92,7 @@ export async function createInlineCommentsFromDiff(diff: string, context: any, a
                         line, // Use the line number in the file
                         side: change.type === 'add' ? 'RIGHT' : 'LEFT', // Specify the side of the diff
                         body,
+                        diff_hunk: diffHunk, 
                     });
                     app.log.info(`Created comment on ${filePath} line ${line}`);
                 } catch (error: any) {

--- a/diffparser.ts
+++ b/diffparser.ts
@@ -1,5 +1,6 @@
 // diffParser.ts
 import parseDiff from 'parse-diff';
+import { start } from 'repl';
 
 // export async function reviewPR(context: any, app: any, llmOutput: any) {
 export async function reviewPR(context: any, app: any) {
@@ -81,7 +82,11 @@ export async function createInlineCommentsFromDiff(diff: string, context: any, a
                     change.type === 'add'
                         ? `Suggested change:\n\`\`\`suggestion\n${content}\n\`\`\``
                         : `Suggested deletion: ${content}`;
-
+                        // start_line: 1,
+                        // start_side: 'RIGHT',
+                        // line: 2,
+                        // side: 'RIGHT',
+                        
                 try {
                     await context.octokit.pulls.createReviewComment({
                         owner: repository.owner.login,
@@ -89,10 +94,13 @@ export async function createInlineCommentsFromDiff(diff: string, context: any, a
                         pull_number: pull_request.number,
                         commit_id: pull_request.head.sha,
                         path: filePath,
-                        line, // Use the line number in the file
                         side: change.type === 'add' ? 'RIGHT' : 'LEFT', // Specify the side of the diff
                         body,
-                        diff_hunk: diffHunk, 
+                        diff_hunk: diffHunk,
+                        position: line,
+                        line,
+                        in_reply_to : null,
+                        subject_type: 'line'
                     });
                     app.log.info(`Created comment on ${filePath} line ${line}`);
                 } catch (error: any) {

--- a/index.ts
+++ b/index.ts
@@ -36,9 +36,10 @@ export default async (app: {
             const prData = await getAllPrDetails(context, app);
             app.log.info(JSON.stringify(prData), "Full PR data collected");
 
-            const llmOutput = await handlePrAnalysis(context, prData , config.apiEndpoint , config.model , app);
-            app.log.info(JSON.stringify(llmOutput), "LLM analysis complete");
-            await reviewPR(context, app, llmOutput);
+            // const llmOutput = await handlePrAnalysis(context, prData , config.apiEndpoint , config.model , app);
+            // app.log.info(JSON.stringify(llmOutput), "LLM analysis complete");
+            // await reviewPR(context, app, llmOutput);
+            await reviewPR(context, app);
             
             // await handleKeployWorkflowTrigger(context);  
             // await handleSecurityWorkflowTrigger(context);

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,7 @@ function subtract(a, b) {
     return a - b;
 }
 
-function multiply(a, b) {
-    return a * b;
-}
+
 
 function divide(a, b) {
     return a / b;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,18 @@
+function add(a, b) {
+    return a - b; // Bug: Subtraction instead of addition
+}
+
+function subtract(a, b) {
+    return a - b;
+}
+
+function multiply(a, b) {
+    return a * b;
+}
+
+function divide(a, b) {
+    return a / b;
+}
+
+
+

--- a/tests/test.js
+++ b/tests/test.js
@@ -3,6 +3,7 @@ describe('Math operations', () => {
         expect(add(2, 3)).toBe(5);
     });
 
+    
     test('subtract should return the difference', () => {
         expect(subtract(5, 3)).toBe(2);
     });

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,9 @@
+describe('Math operations', () => {
+    test('add should return the sum', () => {
+        expect(add(2, 3)).toBe(5);
+    });
+
+    test('subtract should return the difference', () => {
+        expect(subtract(5, 3)).toBe(2);
+    });
+});


### PR DESCRIPTION
Simplify the reviewPR function by eliminating the llmOutput parameter and related code, streamlining the function's logic.